### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ x`//div[@id="foo"]` // 'div#foo'
 
 ## License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.